### PR TITLE
Add weekly agentic AI briefing and improve categories page

### DIFF
--- a/_posts/2025-09-16-weekly-briefing-agentic-gen-ai-stack.md
+++ b/_posts/2025-09-16-weekly-briefing-agentic-gen-ai-stack.md
@@ -1,0 +1,129 @@
+---
+layout: post
+title: "Weekly Briefing: The Agentic Gen-AI Stack Is Getting Practically Useful"
+date: 2025-09-16
+categories: [Agentic AI, Weekly Summary]
+tags: [weekly-briefing, azure-ai-foundry, semantic-kernel, autogen, aws-bedrock, langchain, langgraph, langsmith, crewai, agentic-ai]
+author: Ravindra Naik
+---
+
+# Weekly Briefing: The Agentic Gen-AI Stack Is Getting Practically Useful
+
+_Week of Sep 9–16, 2025 • by an Applied AI Architect (you can be too!)_
+
+## TL;DR — What moved this week and why it matters
+
+- **Azure AI Foundry**: [GPT-5 family models are now available](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/whats-new?utm_source=chatgpt.com) (with Model Router support) and [“Spillover” is GA](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/whats-new?utm_source=chatgpt.com) → higher reasoning options, better cost/latency control, and smoother capacity management.
+- **Semantic Kernel + AutoGen**: Microsoft is [merging AutoGen’s multi-agent features into Semantic Kernel](https://devblogs.microsoft.com/foundry/semantic-kernel-commitment-ai-innovation/?utm_source=chatgpt.com) → one path to production for agentic apps.
+- **AWS Bedrock**: [Inline code nodes in Flows (public preview)](https://aws.amazon.com/blogs/machine-learning/inline-code-nodes-now-supported-in-amazon-bedrock-flows-in-public-preview/?utm_source=chatgpt.com) and [Data Automation upgrades for video](https://aws.amazon.com/blogs/machine-learning/enhance-video-understanding-with-amazon-bedrock-data-automation-and-open-set-object-detection/?utm_source=chatgpt.com) → simpler pipelines, richer multimodal apps.
+- **LangChain + LangGraph + LangSmith**: [v1.0 alpha releases](https://blog.langchain.com/langchain-langchain-1-0-alpha-releases/?utm_source=chatgpt.com), [dynamic tool calling](https://changelog.langchain.com/announcements/dynamic-tool-calling-in-langgraph-agents?utm_source=chatgpt.com), and [Trace Mode in Studio](https://changelog.langchain.com/announcements/trace-mode-in-langgraph-studio?utm_source=chatgpt.com) → safer agent control and tighter observability.
+- **CrewAI**: [Qdrant vector search + RAG support](https://community.crewai.com/t/new-release-0-165-0/6941?utm_source=chatgpt.com), [improved tracing/eventing](https://community.crewai.com/t/crewai-version-0-177-0-release-notes/7008?utm_source=chatgpt.com), and [ongoing changelog updates](https://docs.crewai.com/changelog?utm_source=chatgpt.com) → more production-ready multi-agent orchestration with real memory.
+
+---
+
+## Azure AI Foundry: Smarter model selection and smoother capacity
+
+### What shipped
+
+- **GPT-5 models** are now supported in Azure AI Foundry ([source](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/whats-new?utm_source=chatgpt.com)).
+- **Model Router** can dynamically route prompts across models like `gpt-5`, `gpt-5-mini`, `gpt-5-nano` ([source](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/whats-new?utm_source=chatgpt.com)).
+- **Spillover** is GA to offload provisioned unit traffic bursts ([source](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/whats-new?utm_source=chatgpt.com)).
+
+### Why it matters
+
+You can treat **model choice as policy**: balance cost, latency, and reasoning depth automatically. Spillover prevents downtime during traffic spikes.
+
+### Use cases
+
+- Tiered assistants that start with `nano/mini` and escalate to `gpt-5` only for complex queries.
+- E-commerce peak load: provisioned deployments handle baseline, spillover handles bursts.
+
+---
+
+## Semantic Kernel + AutoGen: One lane to production agents
+
+### What shipped
+
+Microsoft is [aligning AutoGen with Semantic Kernel](https://devblogs.microsoft.com/foundry/semantic-kernel-commitment-ai-innovation/?utm_source=chatgpt.com), unifying multi-agent patterns under one runtime.
+
+### Why it matters
+
+SK brings enterprise connectors + hosting; AutoGen brings agent patterns. Together: fewer moving parts, one supported path to production.
+
+### Use cases
+
+- Host AutoGen agents inside SK, reusing SK connectors for enterprise auth and storage.
+- Build planner/critic/executor loops with SK telemetry and observability built in.
+
+---
+
+## AWS Bedrock: Fewer Lambdas, more multimodal signal
+
+### What shipped
+
+- [Inline code nodes in Bedrock Flows (preview)](https://aws.amazon.com/blogs/machine-learning/inline-code-nodes-now-supported-in-amazon-bedrock-flows-in-public-preview/?utm_source=chatgpt.com) let you embed Python directly into flows.
+- [Data Automation for video](https://aws.amazon.com/blogs/machine-learning/enhance-video-understanding-with-amazon-bedrock-data-automation-and-open-set-object-detection/?utm_source=chatgpt.com) adds open-set object detection, auto-chaptering, and frame-level text detection.
+
+### Why it matters
+
+Inline code removes the need for trivial Lambdas → less ops overhead. Video features unlock richer multimodal AI applications.
+
+### Use cases
+
+- Customer-support bots: preprocess requests inline, enrich with policy checks.
+- Media analytics: detect logos/products in video, chapter long recordings, extract compliance-relevant text.
+
+---
+
+## LangChain + LangGraph + LangSmith: Control + Observability
+
+### What shipped
+
+- [v1.0 alpha of LangChain & LangGraph](https://blog.langchain.com/langchain-langchain-1-0-alpha-releases/?utm_source=chatgpt.com) for both Python & JS.
+- [Dynamic tool calling](https://changelog.langchain.com/announcements/dynamic-tool-calling-in-langgraph-agents?utm_source=chatgpt.com) lets you expose tools contextually, increasing safety.
+- [Trace Mode in LangGraph Studio](https://changelog.langchain.com/announcements/trace-mode-in-langgraph-studio?utm_source=chatgpt.com) integrates with LangSmith for easier debugging.
+- [LangSmith API keys with org roles](https://changelog.langchain.com/?utm_source=chatgpt.com) improve security.
+
+### Why it matters
+
+Safer tool use + deeper observability make LangChain ecosystem much more production-ready.
+
+### Use cases
+
+- Finance ops: only expose payment tools after KYC steps succeed.
+- Incident response: replay prod traces in Studio to debug agent decisions.
+
+---
+
+## CrewAI: RAG memory + cleaner traces in a lean runtime
+
+### What shipped
+
+- [QdrantVectorSearchTool + RAG provider support](https://community.crewai.com/t/new-release-0-165-0/6941?utm_source=chatgpt.com).
+- [Improved tracing and centralized events](https://community.crewai.com/t/crewai-version-0-177-0-release-notes/7008?utm_source=chatgpt.com).
+- [Regular changelog updates](https://docs.crewai.com/changelog?utm_source=chatgpt.com) with flow/CLI improvements.
+
+### Why it matters
+
+Lean multi-agent orchestration with observability + memory. Easy to set up, powerful enough for production.
+
+### Use cases
+
+- Meeting summarizer crew: agents store embeddings in Qdrant and answer follow-ups with citations.
+- Research crew: fact-checker and summarizer agents share vector memory, leaving a trace for audit.
+
+---
+
+## Final Take
+
+This week’s theme: **operationalization**.
+
+Across the stack:
+
+- Azure → policy-driven model choice.
+- AWS → fewer Lambdas, more multimodal features.
+- LangChain ecosystem → safer control & observability.
+- CrewAI → lean, auditable multi-agent flows.
+
+Together, these updates are the missing pieces to **ship agentic systems in production**.
+

--- a/categories.html
+++ b/categories.html
@@ -5,7 +5,7 @@ permalink: /categories/
 description: "Browse posts by category"
 ---
 
-{% assign categories = site.posts | map: "categories" | uniq | sort %}
+{% assign categories = site.categories | sort %}
 
 <div class="categories-header">
   <h1>Categories</h1>
@@ -13,10 +13,11 @@ description: "Browse posts by category"
 </div>
 
 {% for category in categories %}
+  {% assign category_name = category[0] %}
+  {% assign category_posts = category[1] | sort: 'date' | reverse %}
   <div class="category-section">
-    <h2 id="{{ category | downcase | replace: ' ', '-' }}">{{ category }}</h2>
-    {% assign category_posts = site.posts | where_exp: "post", "post.categories contains category" %}
-    
+    <h2 id="{{ category_name | downcase | replace: ' ', '-' }}">{{ category_name }}</h2>
+
     {% for post in category_posts %}
     <article class="blog-post-preview">
       <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>


### PR DESCRIPTION
## Summary
- add a weekly briefing blog post covering the latest agentic AI stack updates and tag it under the new Agentic AI and Weekly Summary categories
- update the categories listing to rely on `site.categories`, ensuring individual categories render with correctly sorted posts

## Testing
- bundle exec jekyll build *(fails: jekyll executable missing; attempted `bundle install` but RubyGems responded with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a916854883339d23a09da1e5671d